### PR TITLE
Added Chase Wave with linear-matrix, zone, threading and 2+ color support

### DIFF
--- a/ChaseFade.py
+++ b/ChaseFade.py
@@ -1,0 +1,202 @@
+import openrgb, time, sys, threading
+from statistics import mean
+from openrgb.utils import RGBColor, ModeData, DeviceType, ZoneType
+
+client = openrgb.OpenRGBClient()
+
+Dlist = client.devices
+
+DEBUG = False
+
+def UserInput():
+    Color1 = Color2 = ReversedDevice = OnlySet = Zones = None
+    Speed = 50
+    for arg in sys.argv:
+        if arg == '--C1':
+            Pos = sys.argv.index(arg) + 1
+            R, G, B = sys.argv[Pos:(Pos + 3)]
+            Color1 = RGBColor(int(R),int(G),int(B))
+        elif arg == '--C2':
+            Pos = sys.argv.index(arg) + 1
+            R, G, B = sys.argv[Pos:(Pos + 3)]
+            Color2 = RGBColor(int(R),int(G),int(B))
+        elif arg == '--colors':
+            Colors = []
+            ColorsSelected = (sys.argv.index(arg) + 1)
+            if ',' in sys.argv[ColorsSelected]:
+                for i in sys.argv[ColorsSelected].split(','):
+                    RGB = i.split()
+                    Colors += [RGBColor(int(RGB[0]), int(RGB[1]), int(RGB[2]))]
+            else:
+                print("You must specify more than one color.")
+                quit()
+        elif arg == '--reversed':
+            ReversedDevices = (sys.argv.index(arg) + 1)
+            ReversedDevice = []
+            if ' , ' in sys.argv[ReversedDevices]:
+                for i in sys.argv[ReversedDevices].split(' , '):
+                    for D in client.devices:
+                        if D.name.strip().casefold() == i.strip().casefold():
+                            ReversedDevice += [D]
+            else:
+                for D in client.devices:
+                    if D.name.strip().casefold() == sys.argv[ReversedDevices].strip().casefold():
+                        ReversedDevice += [D]
+        elif arg == '--only-set':
+            OnlySet = []
+            AllowedDevices = (sys.argv.index(arg) + 1)
+            if ' , ' in sys.argv[AllowedDevices]:
+                for i in sys.argv[AllowedDevices].split(' , '):
+                    for D in client.devices:
+                        if D.name.strip().casefold() == i.strip().casefold():
+                            OnlySet += [D]
+            else:
+                for D in client.devices:
+                    if D.name.strip().casefold() == sys.argv[AllowedDevices].strip().casefold():
+                        OnlySet += [D]
+        elif arg == '--only-zones':
+            Zones = []
+            AllowedZones = (sys.argv.index(arg) + 1)
+            if ' , ' in sys.argv[AllowedZones]:
+                for i in sys.argv[AllowedZones].split(' , '):
+                    for D in client.devices:
+                        for Z in D.zones:
+                            if Z.name.strip().casefold() == i.strip().casefold():
+                                Zones += [Z]
+            else:
+                for D in client.devices:
+                    for Z in D.zones:
+                        if Z.name.strip().casefold() == sys.argv[AllowedZones].strip().casefold():
+                            Zones += [Z]
+        elif arg == '--speed':
+            Speed = int(sys.argv[(sys.argv.index(arg) + 1)])
+        else:
+            pass
+    return(Color1, Color2, Colors, Speed, ReversedDevice, OnlySet, Zones)
+
+def SetStatic(Dlist):
+    """A quick function I use to make sure that everything is in direct or static mode"""
+    for Device in Dlist:
+        time.sleep(0.1)
+        try:
+            Device.set_mode('direct')
+            print('Set %s successfully'%Device.name)
+        except:
+            try:
+                Device.set_mode('static')
+                print('error setting %s\nfalling back to static'%Device.name)
+            except:
+                print("Critical error! couldn't set %s to static or direct"%Device.name)
+
+def Debug(Output):
+    if DEBUG:
+        print(Output)
+
+def InfiniteCycle(Colors, Zone, Passes, Speed):
+    RunThrough = 0
+    FadeCount = 5 * Passes
+    ColorFades = []
+    for i in range(1, len(Colors), 1):
+        RedShift = (Colors[i].red - Colors[0].red)/(FadeCount+1)
+        GreenShift = (Colors[i].green - Colors[0].green)/(FadeCount+1)
+        BlueShift = (Colors[i].blue - Colors[0].blue)/(FadeCount+1)
+        Fades = []
+        for f in range(FadeCount, 0, -1):
+            Fades.append(RGBColor(int(Colors[0].red + (RedShift*f)), int(Colors[0].green + (GreenShift*f)), int(Colors[0].blue + (BlueShift*f))))
+        ColorFades.append(Fades)
+    ColorFadeIndex = 0
+    while True:
+        ZOType = Zone.type
+        if ZOType == ZoneType.SINGLE:
+            RunThrough += 1
+            if (RunThrough%3) == 0:
+                if Zone.colors[0] == Colors[0]:
+                    Zone.colors[0] = (Colors[1])
+                elif Zone.colors[0] == Colors[1]:
+                    Zone.colors[0] = (Colors[0])
+                elif (Zone.colors[0] != Colors[0]) & (Zone.colors[0] != Colors[1]):
+                    Zone.colors[0] = (Colors[1])
+                Zone.show()
+        elif ZOType == ZoneType.LINEAR:
+            if Zone.reverse:
+                Index = Zone.length-Zone.index-1
+            else:
+                Index = Zone.index
+            Debug(f"{Index} =======")
+            for i in range(Zone.length):
+                Zone.colors[i] = Colors[0]
+            for p in range(1, Passes+1, 1):
+                Debug("B:-----------")
+                for f in range(int(FadeCount/Passes)):
+                    if Index < Zone.length-(f+1) and Index+(f+1) >= 0:
+                        if Zone.reverse:
+                            Zone.colors[Index+(f+1)] = ColorFades[ColorFadeIndex][f*Passes+p-1]
+                            Debug(f'i:{Index+(f+1)} p:{p} f:{f} f*Passes+p-1:{f*Passes+p-1} Fade:{ColorFades[ColorFadeIndex][f*Passes+p-1]}')
+                        else:
+                            Zone.colors[Index+(f+1)] = ColorFades[ColorFadeIndex][f*Passes+Passes-p]
+                            Debug(f'i:{Index+(f+1)} p:{p} f:{f} f*Passes+Passes-p:{f*Passes+Passes-p} Fade:{ColorFades[ColorFadeIndex][f*Passes+Passes-p]}')
+                if Index >= 0 and Index < Zone.length:
+                    Zone.colors[Index] = Colors[ColorFadeIndex+1]
+                    Debug(Index)
+                for f in range(int(FadeCount/Passes)):
+                    if Index > f and Index-(f+1) < Zone.length:
+                        if Zone.reverse:
+                            Zone.colors[Index-(f+1)] = ColorFades[ColorFadeIndex][f*Passes+Passes-p]
+                            Debug(f'i:{Index-(f+1)} p:{p} f:{f} f*Passes+Passes-p:{f*Passes+Passes-p} Fade:{ColorFades[ColorFadeIndex][f*Passes+Passes-p]}')
+                        else:
+                            Zone.colors[Index-(f+1)] = ColorFades[ColorFadeIndex][f*Passes+p-1]
+                            Debug(f'i:{Index-(f+1)} p:{p} f:{f} f*Passes+p-1:{f*Passes+p-1} Fade:{ColorFades[ColorFadeIndex][f*Passes+p-1]}')
+                Zone.show()
+                Debug("E:-----------")
+            Zone.index += 1
+            if Zone.index == Zone.length+6:
+                Zone.index = -6
+                if ColorFadeIndex < len(ColorFades)-1:
+                    ColorFadeIndex += 1
+                else:
+                    ColorFadeIndex = 0
+                time.sleep(1)
+        elif ZOType == ZoneType.MATRIX:
+            pass
+            #print('matrix support not done yet')
+
+if __name__ == '__main__':
+    C1, C2, Colors, Speed, Reversed, Enabled, Zones = UserInput()
+    if Colors == None:
+        Colors = []
+        if C1 == None:
+            Colors += [RGBColor(255,0,0)]
+        if C2 == None:
+            Colors += [RGBColor(0,0,255)]
+    Enable = []
+    if Enabled == None:
+        Enable += [i for i in client.devices]
+    elif Enabled != None:
+        Enable = Enabled
+    if Speed > 50:
+        Speed = 50
+    Passes = 51 - Speed
+    if Passes < 1:
+        Passes = 1
+
+    SetStatic(Enable)
+
+    for Device in Enable:
+        ReverseBool = False
+        if Reversed != None:
+            for R in Reversed:
+                if R == Device:
+                    ReverseBool = True
+                    continue
+                else:
+                    ReverseBool = False
+        for zone in Device.zones:
+            if Zones == None or zone in Zones:
+                setattr(zone, 'index', -6)
+                setattr(zone, 'length', len(zone.leds))
+                setattr(zone, 'reverse', ReverseBool)
+                LEDAmount = len(zone.leds) # the amount of leds in a zone
+                Thread = threading.Thread(target=InfiniteCycle, args=(Colors, zone, Passes, Speed), daemon=True)
+                Thread.start()
+
+    Thread.join()

--- a/ChaseFade.py
+++ b/ChaseFade.py
@@ -9,7 +9,7 @@ Dlist = client.devices
 DEBUG = False
 
 def UserInput():
-    Color1 = Color2 = ReversedDevice = OnlySet = Zones = None
+    Color1 = Color2 = Colors = ReversedDevice = OnlySet = Zones = None
     Speed = 50
     for arg in sys.argv:
         if arg == '--C1':
@@ -166,8 +166,12 @@ if __name__ == '__main__':
         Colors = []
         if C1 == None:
             Colors += [RGBColor(255,0,0)]
+        else:
+            Colors += [C1]
         if C2 == None:
             Colors += [RGBColor(0,0,255)]
+        else:
+            Colors += [C2]
     Enable = []
     if Enabled == None:
         Enable += [i for i in client.devices]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 * Chase (Per request of Titanium on Discord)
 
+* Chase Fade (Created by @ Fmstrat on GitHub) (Supports multi-color and rolling colors (matrix wave) for smooth scrolling across LEDs)
+
 * Rave (Basically multiple instances of rain with different colors that make a cool effect, Discovered by Saint Mischievous on discord)
 
 * Stary Night (Per request of BrandonPotter on the discord)
@@ -44,23 +46,29 @@ If you would like a specific effect then DM me on discord (CoffeeIsLife)
 
 Effect (left to right), Flag (top to bottom)
 
-|         | Ambient| Breathing | Chase | Cram | Cycle | Gradcycle | Rain | Rainbow wave | Rave| Stary Night (Twinkle) | TempAware |
-|---------|--------|-----------|-------|------|-------|-----------|------|--------------|-----|-----------------------|-----------|
-|C1       | No     | Yes       | Yes   | Yes  | No    | Yes       | Yes  | No           | No  | Yes                   | No        |
-|C2       | No     | No        | Yes   | No   | No    | Yes       | No   | No           | No  | No                    | No        |
-|Speed    | No     | Yes       | No    | No   | No    | Yes       | No   | Yes          | No  | No                    | No        |
-|Reversed | No     | No        | Yes   | No   | No    | Yes       | Yes  | Yes          | Yes | No                    | No        |
-|Only-Set | No     | Yes       | Yes   | Yes  | Yes   | Yes       | Yes  | Yes          | Yes | Yes                   | No        |
+|           | Ambient| Breathing | Chase | Chase Fade | Cram | Cycle | Gradcycle | Rain | Rainbow wave | Rave| Stary Night (Twinkle) | TempAware |
+|-----------|--------|-----------|-------|------------|------|-------|-----------|------|--------------|-----|-----------------------|-----------|
+|C1         | No     | Yes       | Yes   | Yes        | Yes  | No    | Yes       | Yes  | No           | No  | Yes                   | No        |
+|C2         | No     | No        | Yes   | Yes        | No   | No    | Yes       | No   | No           | No  | No                    | No        |
+|Colors     | No     | No        | No    | Yes        | No   | No    | No        | No   | No           | No  | No                    | No        |
+|Speed      | No     | Yes       | No    | Yes        | No   | No    | Yes       | No   | Yes          | No  | No                    | No        |
+|Reversed   | No     | No        | Yes   | Yes        | No   | No    | Yes       | Yes  | Yes          | Yes | No                    | No        |
+|Only-Set   | No     | Yes       | Yes   | Yes        | Yes  | Yes   | Yes       | Yes  | Yes          | Yes | Yes                   | No        |
+|Only-Zones | No     | No        | No    | Yes        | No   | No    | No        | No   | No           | No  | No                    | No        |
 
 * ``--C1``: AKA Color 1. Usage is ``python file.py --C1 Value(0 - 255) Value(0 - 255) Value(0-255)`` or ``python file --C1 0 0 255``
 
 * ``--C2``: AKA Color 2. Same Usage as C1 but with a different flag
+
+* ``--colors``: An optional replacement for C1 and C2 on effects that support it when you want to use more than 2 colors. Usage is ``python file.py --colors "255 0 0, 0 255 0, 0 0 255"``
 
 * ``--speed``: Self explanitory, It is kinda hard to implement or I am lazy so it isn't in a lot of effects. Usage is ``python file.py --speed int`` (any number is fine but I haven't tested over 50)
 
 * ``--reversed``: Reverses effects for specific devices. Usage is ``python file.py --reversed "example device"`` or ``python file.py --reversed "device 1 , device 2`` for multiple devices. seperate the devices by `` , ``(space comma space)
 
 * ``--only-set``: Used if you only want to apply the effect to one device. I made it a goal for all effects to use this flag. Enables all devices if the flag isn't called. Also same usage as --reversed but with a different flag
+
+* ``--only-zones``: Used if you only want to apply the effect to specific zones. Enables all zones if the flag isn't called. Also same usage as --reversed but with a different flag
 
 ## Writing effects
 
@@ -111,7 +119,7 @@ Python also uses escape characters so if you need to use a \ (Backslash) then yo
 
 ## Todo
 
-* Add matrix zone support for some effects (rainbow wave and gradcycle)
+* Add matrix zone support for some effects (rainbow wave and gradcycle) (included in chase wave)
 
 * Smooth out some of the effects (rainbow wave)
 


### PR DESCRIPTION
I've implemented a Chase Fade effect that also may have elements that can be used in other effects. Full list of features:
- **Matrix wave**: Rather than use a timed delay, an array of differential faded colors is used to create a flowing effect between LEDs
- **2+ colors**: You can specify more than two colors to have more than one chase color cycle
- **Zone specification**: Specify specific zones for the fade to be used in, vs just the device level
- **Threading**: To keep the `show` for one device from slowing down another (and thus making motion jerky as the loop is moving from device to device), each device loop is separated into it's own thread

Try it out with something like:
```
python3 ChaseFade.py --only-set "ASUS Aura Motherboard" --only-zones "Aura Addressable 1" --speed 50 --colors "255 0 0, 0 255 0, 0 0 255"
```
Speed max is 50 (and resets if above), and additional cycles without movement are added based on how you slow down the speed (matrixed).