### PR TITLE
Added Fade effect with --only-leds

### DIFF
--- a/ChaseFade.py
+++ b/ChaseFade.py
@@ -11,6 +11,7 @@ DEBUG = False
 def UserInput():
     Color1 = Color2 = Colors = ReversedDevice = OnlySet = Zones = None
     Speed = 50
+    Delay = 1
     for arg in sys.argv:
         if arg == '--C1':
             Pos = sys.argv.index(arg) + 1
@@ -70,9 +71,11 @@ def UserInput():
                             Zones += [Z]
         elif arg == '--speed':
             Speed = int(sys.argv[(sys.argv.index(arg) + 1)])
+        elif arg == '--delay':
+            Delay = int(sys.argv[(sys.argv.index(arg) + 1)])
         else:
             pass
-    return(Color1, Color2, Colors, Speed, ReversedDevice, OnlySet, Zones)
+    return(Color1, Color2, Colors, Speed, Delay, ReversedDevice, OnlySet, Zones)
 
 def SetStatic(Dlist):
     """A quick function I use to make sure that everything is in direct or static mode"""
@@ -92,7 +95,7 @@ def Debug(Output):
     if DEBUG:
         print(Output)
 
-def InfiniteCycle(Colors, Zone, Passes, Speed):
+def InfiniteCycle(Colors, Zone, Passes, Speed, Delay):
     RunThrough = 0
     FadeCount = 5 * Passes
     ColorFades = []
@@ -155,13 +158,15 @@ def InfiniteCycle(Colors, Zone, Passes, Speed):
                     ColorFadeIndex += 1
                 else:
                     ColorFadeIndex = 0
-                time.sleep(1)
+                if Delay != 0:
+                    time.sleep(Delay)
         elif ZOType == ZoneType.MATRIX:
             pass
             #print('matrix support not done yet')
 
 if __name__ == '__main__':
-    C1, C2, Colors, Speed, Reversed, Enabled, Zones = UserInput()
+    Debug(client.devices)
+    C1, C2, Colors, Speed, Delay, Reversed, Enabled, Zones = UserInput()
     if Colors == None:
         Colors = []
         if C1 == None:
@@ -186,6 +191,7 @@ if __name__ == '__main__':
     SetStatic(Enable)
 
     for Device in Enable:
+        Debug(Device.zones)
         ReverseBool = False
         if Reversed != None:
             for R in Reversed:
@@ -199,8 +205,7 @@ if __name__ == '__main__':
                 setattr(zone, 'index', -6)
                 setattr(zone, 'length', len(zone.leds))
                 setattr(zone, 'reverse', ReverseBool)
-                LEDAmount = len(zone.leds) # the amount of leds in a zone
-                Thread = threading.Thread(target=InfiniteCycle, args=(Colors, zone, Passes, Speed), daemon=True)
+                Thread = threading.Thread(target=InfiniteCycle, args=(Colors, zone, Passes, Speed, Delay), daemon=True)
                 Thread.start()
 
     Thread.join()

--- a/Fade.py
+++ b/Fade.py
@@ -1,0 +1,158 @@
+import openrgb, time, sys, threading
+from statistics import mean
+from openrgb.utils import RGBColor, ModeData, DeviceType, ZoneType
+
+client = openrgb.OpenRGBClient()
+
+Dlist = client.devices
+
+DEBUG = False
+
+def UserInput():
+    Color1 = Color2 = Colors = OnlySet = Zones = LEDs = None
+    Speed = 40
+    Delay = 3
+    for arg in sys.argv:
+        if arg == '--C1':
+            Pos = sys.argv.index(arg) + 1
+            R, G, B = sys.argv[Pos:(Pos + 3)]
+            Color1 = RGBColor(int(R),int(G),int(B))
+        elif arg == '--C2':
+            Pos = sys.argv.index(arg) + 1
+            R, G, B = sys.argv[Pos:(Pos + 3)]
+            Color2 = RGBColor(int(R),int(G),int(B))
+        elif arg == '--colors':
+            Colors = []
+            ColorsSelected = (sys.argv.index(arg) + 1)
+            if ',' in sys.argv[ColorsSelected]:
+                for i in sys.argv[ColorsSelected].split(','):
+                    RGB = i.split()
+                    Colors += [RGBColor(int(RGB[0]), int(RGB[1]), int(RGB[2]))]
+            else:
+                print("You must specify more than one color.")
+                quit()
+        elif arg == '--only-set':
+            OnlySet = []
+            AllowedDevices = (sys.argv.index(arg) + 1)
+            if ' , ' in sys.argv[AllowedDevices]:
+                for i in sys.argv[AllowedDevices].split(' , '):
+                    for D in client.devices:
+                        if D.name.strip().casefold() == i.strip().casefold():
+                            OnlySet += [D]
+            else:
+                for D in client.devices:
+                    if D.name.strip().casefold() == sys.argv[AllowedDevices].strip().casefold():
+                        OnlySet += [D]
+        elif arg == '--only-zones':
+            Zones = []
+            AllowedZones = (sys.argv.index(arg) + 1)
+            if ' , ' in sys.argv[AllowedZones]:
+                for i in sys.argv[AllowedZones].split(' , '):
+                    for D in client.devices:
+                        for Z in D.zones:
+                            if Z.name.strip().casefold() == i.strip().casefold():
+                                Zones += [Z]
+            else:
+                for D in client.devices:
+                    for Z in D.zones:
+                        if Z.name.strip().casefold() == sys.argv[AllowedZones].strip().casefold():
+                            Zones += [Z]
+        elif arg == '--only-leds':
+            AllowedLEDs = sys.argv[(sys.argv.index(arg) + 1)]
+            LEDs = []
+            for s in AllowedLEDs.split(','):
+                LEDs += [int(s.strip())]
+        elif arg == '--speed':
+            Speed = int(sys.argv[(sys.argv.index(arg) + 1)])
+        elif arg == '--delay':
+            Delay = int(sys.argv[(sys.argv.index(arg) + 1)])
+        else:
+            pass
+    return(Color1, Color2, Colors, Speed, Delay, OnlySet, Zones, LEDs)
+
+def SetStatic(Dlist):
+    """A quick function I use to make sure that everything is in direct or static mode"""
+    for Device in Dlist:
+        time.sleep(0.1)
+        try:
+            Device.set_mode('direct')
+            print('Set %s successfully'%Device.name)
+        except:
+            try:
+                Device.set_mode('static')
+                print('error setting %s\nfalling back to static'%Device.name)
+            except:
+                print("Critical error! couldn't set %s to static or direct"%Device.name)
+
+def Debug(Output):
+    if DEBUG:
+        print(Output)
+
+def InfiniteCycle(Colors, Zone, Speed, Delay, LEDs):
+    RunThrough = 0
+    FadeCount = 501-(Speed*10)
+    ColorFades = []
+    Debug(Colors)
+    for i in range(len(Colors)):
+        if i == len(Colors)-1:
+            ReferenceIndex = 0
+        else:
+            ReferenceIndex = i+1
+        RedShift = (Colors[i].red - Colors[ReferenceIndex].red)/(FadeCount+1)
+        GreenShift = (Colors[i].green - Colors[ReferenceIndex].green)/(FadeCount+1)
+        BlueShift = (Colors[i].blue - Colors[ReferenceIndex].blue)/(FadeCount+1)
+        Fades = []
+        Fades.append(Colors[i])
+        for f in range(FadeCount):
+            Debug(RGBColor(int(Colors[i].red - (RedShift*f)), int(Colors[i].green - (GreenShift*f)), int(Colors[i].blue - (BlueShift*f))))
+            Fades.append(RGBColor(int(Colors[i].red - (RedShift*f)), int(Colors[i].green - (GreenShift*f)), int(Colors[i].blue - (BlueShift*f))))
+        ColorFades.append(Fades)
+    while True:
+        for ColorFade in ColorFades:
+            Debug(ColorFade)
+            for Fade in ColorFade:
+                Debug(Fade)
+                if Zone.type == ZoneType.SINGLE:
+                    Zone.colors[0] = Fade
+                    Zone.show()
+                elif Zone.type == ZoneType.LINEAR:
+                    for i in range(Zone.length):
+                        if LEDs is None or i in LEDs: 
+                            Zone.colors[i] = Fade
+                    Zone.show()
+                elif Zone.type == ZoneType.MATRIX:
+                    pass
+                    #print('matrix support not done yet')
+            if Delay != 0:
+                time.sleep(Delay)
+
+if __name__ == '__main__':
+    C1, C2, Colors, Speed, Delay, Enabled, Zones, LEDs = UserInput()
+    if Colors == None:
+        Colors = []
+        if C1 == None:
+            Colors += [RGBColor(255,0,0)]
+        else:
+            Colors += [C1]
+        if C2 == None:
+            Colors += [RGBColor(0,0,255)]
+        else:
+            Colors += [C2]
+    Enable = []
+    if Enabled == None:
+        Enable += [i for i in client.devices]
+    elif Enabled != None:
+        Enable = Enabled
+    if Speed > 50:
+        Speed = 50
+
+    SetStatic(Enable)
+
+    for Device in Enable:
+        for zone in Device.zones:
+            if Zones == None or zone in Zones:
+                setattr(zone, 'length', len(zone.leds))
+                Thread = threading.Thread(target=InfiniteCycle, args=(Colors, zone, Speed, Delay, LEDs), daemon=True)
+                Thread.start()
+
+    Thread.join()

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Effect (left to right), Flag (top to bottom)
 |C2         | No     | No        | Yes   | Yes        | No   | No    | Yes       | No   | No           | No  | No                    | No        |
 |Colors     | No     | No        | No    | Yes        | No   | No    | No        | No   | No           | No  | No                    | No        |
 |Speed      | No     | Yes       | No    | Yes        | No   | No    | Yes       | No   | Yes          | No  | No                    | No        |
+|Delay      | No     | No        | No    | Yes        | No   | No    | No        | No   | No           | No  | No                    | No        |
 |Reversed   | No     | No        | Yes   | Yes        | No   | No    | Yes       | Yes  | Yes          | Yes | No                    | No        |
 |Only-Set   | No     | Yes       | Yes   | Yes        | Yes  | Yes   | Yes       | Yes  | Yes          | Yes | Yes                   | No        |
 |Only-Zones | No     | No        | No    | Yes        | No   | No    | No        | No   | No           | No  | No                    | No        |
@@ -63,6 +64,8 @@ Effect (left to right), Flag (top to bottom)
 * ``--colors``: An optional replacement for C1 and C2 on effects that support it when you want to use more than 2 colors. Usage is ``python file.py --colors "255 0 0, 0 255 0, 0 0 255"``
 
 * ``--speed``: Self explanitory, It is kinda hard to implement or I am lazy so it isn't in a lot of effects. Usage is ``python file.py --speed int`` (any number is fine but I haven't tested over 50)
+
+* ``--delay``: When an effect is between transitions or fades, set the number of seconds it should wait to start the next transition or fade. Usage is ``python file.py --delay int``
 
 * ``--reversed``: Reverses effects for specific devices. Usage is ``python file.py --reversed "example device"`` or ``python file.py --reversed "device 1 , device 2`` for multiple devices. seperate the devices by `` , ``(space comma space)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 * Chase Fade (Created by @ Fmstrat on GitHub) (Supports multi-color and rolling colors (matrix wave) for smooth scrolling across LEDs)
 
+* Fade (Created by @ Fmstrat on GitHub) (Supports multi-color and rolling colors for smooth transitions between colors)
+
 * Rave (Basically multiple instances of rain with different colors that make a cool effect, Discovered by Saint Mischievous on discord)
 
 * Stary Night (Per request of BrandonPotter on the discord)
@@ -46,16 +48,17 @@ If you would like a specific effect then DM me on discord (CoffeeIsLife)
 
 Effect (left to right), Flag (top to bottom)
 
-|           | Ambient| Breathing | Chase | Chase Fade | Cram | Cycle | Gradcycle | Rain | Rainbow wave | Rave| Stary Night (Twinkle) | TempAware |
-|-----------|--------|-----------|-------|------------|------|-------|-----------|------|--------------|-----|-----------------------|-----------|
-|C1         | No     | Yes       | Yes   | Yes        | Yes  | No    | Yes       | Yes  | No           | No  | Yes                   | No        |
-|C2         | No     | No        | Yes   | Yes        | No   | No    | Yes       | No   | No           | No  | No                    | No        |
-|Colors     | No     | No        | No    | Yes        | No   | No    | No        | No   | No           | No  | No                    | No        |
-|Speed      | No     | Yes       | No    | Yes        | No   | No    | Yes       | No   | Yes          | No  | No                    | No        |
-|Delay      | No     | No        | No    | Yes        | No   | No    | No        | No   | No           | No  | No                    | No        |
-|Reversed   | No     | No        | Yes   | Yes        | No   | No    | Yes       | Yes  | Yes          | Yes | No                    | No        |
-|Only-Set   | No     | Yes       | Yes   | Yes        | Yes  | Yes   | Yes       | Yes  | Yes          | Yes | Yes                   | No        |
-|Only-Zones | No     | No        | No    | Yes        | No   | No    | No        | No   | No           | No  | No                    | No        |
+|           | Ambient| Breathing | Chase | Chase Fade | Cram | Cycle | Fade | Gradcycle | Rain | Rainbow wave | Rave| Stary Night (Twinkle) | TempAware |
+|-----------|--------|-----------|-------|------------|------|-------|------|-----------|------|--------------|-----|-----------------------|-----------|
+|C1         | No     | Yes       | Yes   | Yes        | Yes  | No    | Yes  | Yes       | Yes  | No           | No  | Yes                   | No        |
+|C2         | No     | No        | Yes   | Yes        | No   | No    | Yes  | Yes       | No   | No           | No  | No                    | No        |
+|Colors     | No     | No        | No    | Yes        | No   | No    | Yes  | No        | No   | No           | No  | No                    | No        |
+|Speed      | No     | Yes       | No    | Yes        | No   | No    | Yes  | Yes       | No   | Yes          | No  | No                    | No        |
+|Delay      | No     | No        | No    | Yes        | No   | No    | Yes  | No        | No   | No           | No  | No                    | No        |
+|Reversed   | No     | No        | Yes   | Yes        | No   | No    | No   | Yes       | Yes  | Yes          | Yes | No                    | No        |
+|Only-Set   | No     | Yes       | Yes   | Yes        | Yes  | Yes   | Yes  | Yes       | Yes  | Yes          | Yes | Yes                   | No        |
+|Only-Zones | No     | No        | No    | Yes        | No   | No    | Yes  | No        | No   | No           | No  | No                    | No        |
+|Only-LEDs  | No     | No        | No    | No         | No   | No    | Yes  | No        | No   | No           | No  | No                    | No        |
 
 * ``--C1``: AKA Color 1. Usage is ``python file.py --C1 Value(0 - 255) Value(0 - 255) Value(0-255)`` or ``python file --C1 0 0 255``
 
@@ -72,6 +75,8 @@ Effect (left to right), Flag (top to bottom)
 * ``--only-set``: Used if you only want to apply the effect to one device. I made it a goal for all effects to use this flag. Enables all devices if the flag isn't called. Also same usage as --reversed but with a different flag
 
 * ``--only-zones``: Used if you only want to apply the effect to specific zones. Enables all zones if the flag isn't called. Also same usage as --reversed but with a different flag
+
+* ``--only-leds``: Used if you only want to apply the effect to a single LEDs in a linear type. Enables all LEDs if the flag isn't called. Usage is ``python file.py --only-leds "0, 2"``
 
 ## Writing effects
 


### PR DESCRIPTION
Created a cycling fade effect that supports 2+ colors, delays, speed, and a new option for `--only-leds`. This allows you to specify a single LED to fade between colors which is useful when you have a motherboard where a single LED is assigned to an RGB header, like Asus, where the LEDs are:
- 0-2: Motherboard itself
- 3: RGB header 1
- 4: RGB header 2

This should be merged after PR https://github.com/herosilas12/OpenRGB-python-FX/pull/4